### PR TITLE
Fix torcwa for torch 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Installation
 
 	* Python version 3.8 or higher
 
-	* PyTorch version 1.10.1 or higher
+        * PyTorch version 2.0 or higher
 
 	* For GPU operation, GPUs that support CUDA operations
 
@@ -55,7 +55,7 @@ Installation
 ```
 $ pip install torcwa
 ```
-* If the PyTorch version is lower than the required, it will automatically install PyTorch 1.10.1 or higher, but the CPU-only PyTorch or incompatible version may be installed. Therefore, **before installing using the above command, please install PyTorch version that is compatible with GPU**.
+* If the PyTorch version is lower than the required, it will automatically install PyTorch 2.0 or higher, but the CPU-only PyTorch or incompatible version may be installed. Therefore, **before installing using the above command, please install a GPU-compatible PyTorch version**.
 
 <br/>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch>=1.10.1
+torch>=2.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author_email='kch3782@snu.ac.kr',
     license='LGPL',
     url='https://github.com/kch3782/torcwa',
-    install_requires=['torch>=1.10.1'],
+    install_requires=['torch>=2.0'],
     dependency_links=['https://download.pytorch.org/whl/torch_stable.html'],
     packages=find_packages(),
     keywords='torcwa',

--- a/torcwa/rcwa.py
+++ b/torcwa/rcwa.py
@@ -63,8 +63,8 @@ class rcwa:
 
         # Fourier order
         self.order = order
-        self.order_x = torch.linspace(-self.order[0],self.order[0],2*self.order[0]+1,dtype=torch.int64,device=self._device)
-        self.order_y = torch.linspace(-self.order[1],self.order[1],2*self.order[1]+1,dtype=torch.int64,device=self._device)
+        self.order_x = torch.arange(-self.order[0], self.order[0]+1, dtype=torch.int64, device=self._device)
+        self.order_y = torch.arange(-self.order[1], self.order[1]+1, dtype=torch.int64, device=self._device)
         self.order_N = len(self.order_x)*len(self.order_y)
 
         # Lattice vector

--- a/torcwa/torch_eig.py
+++ b/torcwa/torch_eig.py
@@ -1,7 +1,7 @@
 import torch
 
 '''
-Pytorch 1.10.1
+Pytorch 2.0+
 Complex domain eigen-decomposition with numerical stability
 '''
 
@@ -32,7 +32,7 @@ class Eig(torch.autograd.Function):
         elif s.dtype == torch.complex128:
             F = torch.conj(s)/(torch.abs(s)**2 + 4.9e-324)
 
-        diag_indices = torch.linspace(0,F.shape[-1]-1,F.shape[-1],dtype=torch.int64)
+        diag_indices = torch.arange(0, F.shape[-1], dtype=torch.int64)
         F[diag_indices,diag_indices] = 0.
         XH = torch.transpose(torch.conj(eigvec),-2,-1)
         tmp = torch.conj(F) * torch.matmul(XH, grad_eigvec)


### PR DESCRIPTION
## Summary
- support newer PyTorch by using `torch.arange` for integer ranges
- bump torch requirement to 2.0
- update documentation with new version
- mention torch 2.0 in `torch_eig.py`

## Testing
- `python -m compileall -q torcwa`